### PR TITLE
refactor(Execute): hang preprocess funcs off of config

### DIFF
--- a/internal/instructions/execute.go
+++ b/internal/instructions/execute.go
@@ -15,33 +15,18 @@ import (
 var log = logging.MustGetLogger("instructions") //nolint:gochecknoglobals
 
 // Execute takes in configuratation options and executes overlays on an instruction file specified.
-// nolint:cyclop
 func Execute(cfg *Config) error {
 	eg, ctx := errgroup.WithContext(context.Background())
 
-	values, err := getValues(cfg.Values)
+	instructions, err := cfg.ReadInstructionFile()
 	if err != nil {
 		return err
 	}
-
-	instructions, err := ReadInstructionFile(&cfg.InstructionsFile, values)
-	if err != nil {
-		return err
-	}
-
-	instructions.addCommonOverlays()
 
 	pChan := make(chan *YamlFile, len(instructions.YamlFiles))
 
 	for _, yamlFile := range instructions.YamlFiles {
 		yf := yamlFile
-
-		// remove the comments if requested
-		if cfg.RemoveComments {
-			for _, node := range yf.Nodes {
-				removeCommentsFromNode(node)
-			}
-		}
 
 		eg.Go(
 			func() error {


### PR DESCRIPTION
move value gathering and comment removal to
ReadInstructionFile to simplify complexity.

Signed-off-by: Jeff Davis <jeffda@vmware.com>