### PR TITLE
fix: correct issue with single file path going to root

### DIFF
--- a/internal/instructions/utils.go
+++ b/internal/instructions/utils.go
@@ -38,7 +38,7 @@ func GetCommonPrefix(sep byte, paths ...string) string {
 	case 0:
 		return ""
 	case 1:
-		return path.Dir(path.Clean(paths[0]))
+		return path.Dir(path.Clean(paths[0])) + string(os.PathSeparator)
 	}
 
 	c := path.Clean(paths[0]) + string(sep)


### PR DESCRIPTION
found issue where if a single file is specified in instructions
that file tries to write to root which causes a read only file system error

Signed-off-by: Jeff Davis <jeffda@vmware.com>